### PR TITLE
Remove Inactive WGs

### DIFF
--- a/contribute_to_node.md
+++ b/contribute_to_node.md
@@ -9,8 +9,6 @@ and we'll label your request as `intro requested`. A collaborator will facilitat
 ### Group contributing guides
 - [Website WG](https://github.com/nodejs/nodejs.org/blob/master/CONTRIBUTING.md#nodejs-community-contributing-guide-10)<br>
   The Website Working Group is primarily concerned with the code and overall structure of the [Node.js](https://nodejs.org) website.
-- [HTTP2](https://github.com/nodejs/http2/blob/master/CONTRIBUTING.md#contributing-to-nodejs)<br>
-  This repository focuses on an HTTP/2 implementation for Node.js Core
 - [citgm](https://github.com/nodejs/citgm/blob/master/CONTRIBUTING.md#making-changes-to-citgm)<br>
   citgm is a tool for pulling down an arbitrary module from npm and testing it using a specific version of the node runtime. The Node.js project uses citgm to smoketest releases and controversial changes.
 - [Diagnostics WG](https://github.com/nodejs/diagnostics#diagnostics-working-group)<br>

--- a/contribute_to_node.md
+++ b/contribute_to_node.md
@@ -9,8 +9,6 @@ and we'll label your request as `intro requested`. A collaborator will facilitat
 ### Group contributing guides
 - [Website WG](https://github.com/nodejs/nodejs.org/blob/master/CONTRIBUTING.md#nodejs-community-contributing-guide-10)<br>
   The Website Working Group is primarily concerned with the code and overall structure of the [Node.js](https://nodejs.org) website.
-- [Docs WG](https://github.com/nodejs/docs/blob/master/CONTRIBUTING.md#contributing-to-the-docs)<br>
-  This group serves as a central place for Node.js documentation coordination, but not documentation itself. They will help get you there.
 - [HTTP2](https://github.com/nodejs/http2/blob/master/CONTRIBUTING.md#contributing-to-nodejs)<br>
   This repository focuses on an HTTP/2 implementation for Node.js Core
 - [citgm](https://github.com/nodejs/citgm/blob/master/CONTRIBUTING.md#making-changes-to-citgm)<br>


### PR DESCRIPTION
Removes the Docs WG and HTTP/2 WG - as far as I can tell, Docs is defunct and most work is done in Core (ref: https://github.com/nodejs/docs/issues/127) and the same goes for HTTP/2 now that it's merged - I may be wrong on that one though!